### PR TITLE
single id for keepalive

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --fix --ext .ts",
     "test": "mocha -r ts-node/register tests/**/*.spec.ts",
     "test:coverage": "nyc npm run test",
     "build:init": "rm -rf ../deployment/* && mkdir -p ../deployment/",


### PR DESCRIPTION
mqtt-to-mqtt: use a single clientId for keepalive
linting corrections